### PR TITLE
Add guide support for T11/T12 athletes

### DIFF
--- a/blueprints/admin/forms.py
+++ b/blueprints/admin/forms.py
@@ -143,7 +143,8 @@ class ResultForm(FlaskForm):
 
 class StartListForm(FlaskForm):
     athlete_sdms = IntegerField('Athlete SDMS', validators=[DataRequired()])
-    lane_order = IntegerField('Lane/Order', validators=[Optional(), NumberRange(min=1)])\
+    lane_order = IntegerField('Lane/Order', validators=[Optional(), NumberRange(min=1)])
+    guide_sdms = IntegerField('Guide SDMS', validators=[Optional()])
 
 class HighJumpHeightsForm(FlaskForm):
     heights = StringField('Heights (comma-separated)',

--- a/blueprints/admin/routes/results.py
+++ b/blueprints/admin/routes/results.py
@@ -137,6 +137,7 @@ def register_routes(bp):
                 return redirect(url_for('admin.games_list'))
 
             athlete_sdms = request.form.get('athlete_sdms')
+            guide_sdms = request.form.get('guide_sdms')
             value = request.form.get('value', '').strip() if request.form.get('value') else ''
             weight_raw = request.form.get('weight')
             weight = weight_raw.strip() if weight_raw else None
@@ -169,6 +170,12 @@ def register_routes(bp):
                 except (ValueError, TypeError):
                     errors.append('Invalid athlete SDMS')
 
+            if guide_sdms:
+                try:
+                    guide_sdms = int(guide_sdms)
+                except (ValueError, TypeError):
+                    guide_sdms = None
+
             # High Jump special handling
             if game['event'] == 'High Jump':
                 height = request.form.get('height')
@@ -194,6 +201,7 @@ def register_routes(bp):
                     result_data = {
                         'game_id': game_id,
                         'athlete_sdms': athlete_sdms,
+                        'guide_sdms': guide_sdms,
                         'value': 'NH',  # No Height initially
                         'raza_score': 0,
                         'raza_score_precise': 0.0
@@ -549,6 +557,7 @@ def register_routes(bp):
                 result_data = {
                     'game_id': game_id,
                     'athlete_sdms': athlete_sdms,
+                    'guide_sdms': guide_sdms,
                     'value': performance_value,
                     'best_attempt': f"{performance_value:.2f}" if performance_value != "NM" else None,
                     'raza_score': max_raza_score,
@@ -603,6 +612,7 @@ def register_routes(bp):
                 result_data = {
                     'game_id': game_id,
                     'athlete_sdms': athlete_sdms,
+                    'guide_sdms': guide_sdms,
                     'value': performance_value,
                     'raza_score': max_raza_score,
                     'raza_score_precise': max_raza_score_precise

--- a/blueprints/admin/routes/startlists.py
+++ b/blueprints/admin/routes/startlists.py
@@ -36,8 +36,10 @@ def register_routes(bp):
                     flash(f"Warning: Athlete class {athlete['class']} not in game classes {', '.join(game_classes)}",
                         'warning')
 
+                guide_sdms = form.guide_sdms.data if form.guide_sdms.data else None
+
                 try:
-                    StartList.create(game_id, form.athlete_sdms.data, form.lane_order.data)
+                    StartList.create(game_id, form.athlete_sdms.data, form.lane_order.data, guide_sdms)
                     flash('Athlete added to start list', 'success')
                 except Exception as e:
                     flash(f'Error adding to start list: {str(e)}', 'danger')

--- a/config.py
+++ b/config.py
@@ -133,6 +133,14 @@ class Config:
             return ['Shot Put', 'Discus Throw', 'Javelin Throw', 'Hammer Throw', 'Club Throw', 'Weight Throw']
 
     @staticmethod
+    def get_guide_classes():
+        try:
+            from database.config_manager import ConfigManager
+            return ConfigManager.get_config_tags('guide_classes')
+        except (ImportError, Exception):
+            return ['T11', 'T12']
+
+    @staticmethod
     def get_current_day():
         try:
             from database.config_manager import ConfigManager

--- a/database/config_manager.py
+++ b/database/config_manager.py
@@ -113,7 +113,7 @@ class ConfigManager:
                 result[key] = value
 
         tag_configs = ['classes', 'record_types', 'result_special_values', 'field_events', 'track_events',
-                       'wind_affected_field_events', 'weight_field_events']
+                       'wind_affected_field_events', 'weight_field_events', 'guide_classes']
         for key in tag_configs:
             result[key] = ConfigManager.get_config_tags(key)
 

--- a/database/db_manager.py
+++ b/database/db_manager.py
@@ -134,6 +134,7 @@ def init_db():
             gender VARCHAR(10) NOT NULL,
             class VARCHAR(10) NOT NULL,
             photo VARCHAR(255),
+            is_guide BOOLEAN DEFAULT FALSE,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )""",
 
@@ -163,6 +164,7 @@ def init_db():
             id SERIAL PRIMARY KEY,
             game_id INTEGER NOT NULL,
             athlete_sdms INTEGER NOT NULL,
+            guide_sdms INTEGER,
             rank VARCHAR(10),
             value VARCHAR(20) NOT NULL,
             raza_score INTEGER,
@@ -181,6 +183,7 @@ def init_db():
             id SERIAL PRIMARY KEY,
             game_id INTEGER NOT NULL,
             athlete_sdms INTEGER NOT NULL,
+            guide_sdms INTEGER,
             lane_order INTEGER,
             final_order INTEGER,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -341,6 +344,7 @@ def insert_default_config():
             'Marathon', '4x100m Relay', '4x400m Relay', 'Universal Relay',
             'Long Jump', 'High Jump', 'Triple Jump', 'Pole Vault'
         ]),
+        ('guide_classes', ['T11', 'T12']),
         ('wind_affected_field_events', ['Long Jump', 'Triple Jump', '100m', '200m']),
         ('weight_field_events', [
             'Shot Put', 'Discus Throw', 'Javelin Throw', 'Hammer Throw',

--- a/database/models.py
+++ b/database/models.py
@@ -370,9 +370,11 @@ class Result:
     @staticmethod
     def get_all(**filters):
         query = """
-            SELECT r.*, a.firstname, a.lastname, a.country, a.gender as athlete_gender, a.class as athlete_class
+            SELECT r.*, a.firstname, a.lastname, a.country, a.gender as athlete_gender, a.class as athlete_class,
+                   g.firstname AS guide_firstname, g.lastname AS guide_lastname
             FROM results r
             JOIN athletes a ON r.athlete_sdms = a.sdms
+            LEFT JOIN athletes g ON r.guide_sdms = g.sdms
             WHERE 1=1
         """
         params = []
@@ -633,19 +635,21 @@ class StartList:
     @staticmethod
     def get_by_game(game_id):
         query = """
-            SELECT s.*, a.firstname, a.lastname, a.country, a.class, a.gender
+            SELECT s.*, a.firstname, a.lastname, a.country, a.class, a.gender,
+                   g.firstname AS guide_firstname, g.lastname AS guide_lastname
             FROM startlist s
             JOIN athletes a ON s.athlete_sdms = a.sdms
+            LEFT JOIN athletes g ON s.guide_sdms = g.sdms
             WHERE s.game_id = %s
             ORDER BY s.final_order IS NULL, s.final_order, s.lane_order, a.sdms
         """
         return execute_query(query, (game_id,), fetch=True)
 
     @staticmethod
-    def create(game_id, athlete_sdms, lane_order=None):
+    def create(game_id, athlete_sdms, lane_order=None, guide_sdms=None):
         return execute_query(
-            "INSERT INTO startlist (game_id, athlete_sdms, lane_order) VALUES (%s, %s, %s)",
-            (game_id, athlete_sdms, lane_order)
+            "INSERT INTO startlist (game_id, athlete_sdms, lane_order, guide_sdms) VALUES (%s, %s, %s, %s)",
+            (game_id, athlete_sdms, lane_order, guide_sdms)
         )
 
     @staticmethod

--- a/static/js/manage_results.js
+++ b/static/js/manage_results.js
@@ -101,16 +101,26 @@ function selectAthlete(athlete) {
     const athleteSearch = document.getElementById('athleteSearch');
     const athleteResults = document.getElementById('athleteResults');
     const selectedAthlete = document.getElementById('selectedAthlete');
+    const selectedGuideSdms = document.getElementById('selectedGuideSdms');
+    const selectedGuide = document.getElementById('selectedGuide');
 
     if (selectedSdms) selectedSdms.value = athlete.sdms;
     if (athleteSearch) athleteSearch.value = '';
     if (athleteResults) athleteResults.classList.add('hidden');
     if (selectedAthlete) selectedAthlete.innerHTML = `Selected: <strong>${athlete.sdms}</strong> - ${athlete.name}`;
+    if (selectedGuideSdms) selectedGuideSdms.value = '';
+    if (selectedGuide) selectedGuide.innerHTML = '';
 }
 
-function selectFromStartList(sdms, name, gender, athleteClass) {
+function selectFromStartList(sdms, name, gender, athleteClass, guideSdms) {
     const athlete = { sdms: sdms, name: name, gender: gender, class: athleteClass };
     selectAthlete(athlete);
+    if (guideSdms) {
+        const selectedGuideSdms = document.getElementById('selectedGuideSdms');
+        const selectedGuide = document.getElementById('selectedGuide');
+        if (selectedGuideSdms) selectedGuideSdms.value = guideSdms;
+        if (selectedGuide) selectedGuide.innerHTML = `Guide SDMS: <strong>${guideSdms}</strong>`;
+    }
 }
 
 function selectSpecialValue(value) {

--- a/templates/admin/config/general.html
+++ b/templates/admin/config/general.html
@@ -51,6 +51,29 @@
             </div>
         </div>
 
+        <!-- Classes With Guides -->
+        <div class="bg-white rounded-lg shadow p-6">
+            <h3 class="text-lg font-bold mb-4">Guide Allowed Classes</h3>
+            <div class="tag-manager" data-config-key="guide_classes">
+                <div class="flex flex-wrap gap-2 mb-3 min-h-[40px] p-2 border rounded bg-gray-50" id="guide_classes-tags">
+                    {% for cls in configs.get('guide_classes', []) %}
+                    <span class="tag inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-purple-100 text-purple-800">
+                        {{ cls }}
+                        <button type="button" class="ml-2 text-purple-600 hover:text-purple-800" onclick="removeTag('guide_classes', '{{ cls }}')">
+                            <i class="fas fa-times"></i>
+                        </button>
+                    </span>
+                    {% endfor %}
+                </div>
+                <div class="flex">
+                    <input type="text" id="guide_classes-input" placeholder="Add class (e.g., T11)" class="flex-1 px-3 py-2 border rounded-l-lg">
+                    <button type="button" onclick="addTag('guide_classes')" class="bg-purple-500 text-white px-4 py-2 rounded-r-lg hover:bg-purple-600">
+                        Add
+                    </button>
+                </div>
+            </div>
+        </div>
+
         <!-- Record Types -->
         <div class="bg-white rounded-lg shadow p-6">
             <h3 class="text-lg font-bold mb-4">Record Types</h3>
@@ -254,6 +277,7 @@
             <p><strong>Special Values:</strong> DNS=Did Not Start, DNF=Did Not Finish, DSQ=Disqualified, etc.</p>
             <p><strong>Wind-Affected Field Events:</strong> Field events where wind velocity measurement is relevant</p>
             <p><strong>Weight Field Events:</strong> Events where implements have different weights for different classes</p>
+            <p><strong>Guide Allowed Classes:</strong> Classes where athletes may have a guide (e.g., T11, T12)</p>
         </div>
     </div>
 </div>

--- a/templates/admin/games/startlist.html
+++ b/templates/admin/games/startlist.html
@@ -28,7 +28,7 @@
         <form method="POST" action="{{ url_for('admin.startlist_add', game_id=game.id) }}">
             {{ form.hidden_tag() }}
 
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
                 <div>
                     <label class="block text-gray-700 text-sm font-bold mb-2">Athlete</label>
                     <div class="relative">
@@ -38,6 +38,17 @@
                     </div>
                     <input type="hidden" name="athlete_sdms" id="selectedSdms" required>
                     <div id="selectedAthlete" class="mt-2 text-sm text-gray-600" data-game-classes="{{ game.classes }}" data-game-gender="{{ game.gender }}"></div>
+                </div>
+
+                <div>
+                    <label class="block text-gray-700 text-sm font-bold mb-2">Guide (optional)</label>
+                    <div class="relative">
+                        <input type="text" id="guideSearch" placeholder="Search guide"
+                               class="w-full px-3 py-2 border rounded-lg focus:outline-none focus:border-red-500">
+                        <div id="guideResults" class="absolute z-10 w-full bg-white border rounded-lg shadow-lg mt-1 hidden max-h-60 overflow-y-auto"></div>
+                    </div>
+                    <input type="hidden" name="guide_sdms" id="selectedGuideSdms">
+                    <div id="selectedGuide" class="mt-2 text-sm text-gray-600"></div>
                 </div>
 
                 <div>
@@ -76,6 +87,7 @@
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Country</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Gender</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Class</th>
+                    <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Guide</th>
                     <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                 </tr>
             </thead>
@@ -140,6 +152,16 @@
                             <span class="text-red-500 ml-1" title="Class not in event">
                                 <i class="fas fa-exclamation-triangle"></i>
                             </span>
+                        {% endif %}
+                    </td>
+
+                    <!-- Guide -->
+                    <td class="px-6 py-4 whitespace-nowrap">
+                        {% if entry.guide_sdms %}
+                            <span class="bg-indigo-100 text-indigo-800 px-2 py-1 rounded text-sm font-semibold">{{ entry.guide_sdms }}</span>
+                            <div class="text-xs text-gray-600">{{ entry.guide_lastname }} {{ entry.guide_firstname }}</div>
+                        {% else %}
+                            <span class="text-gray-400">-</span>
                         {% endif %}
                     </td>
 
@@ -252,6 +274,10 @@ const athleteSearch = document.getElementById('athleteSearch');
 const athleteResults = document.getElementById('athleteResults');
 const selectedSdms = document.getElementById('selectedSdms');
 const selectedAthlete = document.getElementById('selectedAthlete');
+const guideSearch = document.getElementById('guideSearch');
+const guideResults = document.getElementById('guideResults');
+const selectedGuideSdms = document.getElementById('selectedGuideSdms');
+const selectedGuide = document.getElementById('selectedGuide');
 
 athleteSearch.addEventListener('input', function() {
     clearTimeout(searchTimeout);
@@ -311,6 +337,43 @@ athleteSearch.addEventListener('input', function() {
     }, 300);
 });
 
+guideSearch.addEventListener('input', function() {
+    clearTimeout(searchTimeout);
+    const query = this.value.trim();
+
+    if (query.length < 2) {
+        guideResults.classList.add('hidden');
+        return;
+    }
+
+    searchTimeout = setTimeout(() => {
+        fetch(`/admin/athletes/search?q=${encodeURIComponent(query)}`)
+            .then(response => response.json())
+            .then(athletes => {
+                guideResults.innerHTML = '';
+                if (athletes.length === 0) {
+                    guideResults.innerHTML = '<div class="p-2 text-gray-500">No athletes found</div>';
+                } else {
+                    athletes.forEach(athlete => {
+                        const div = document.createElement('div');
+                        div.className = 'p-2 hover:bg-gray-100 cursor-pointer border-b';
+                        div.innerHTML = `<strong>${athlete.sdms}</strong> - ${athlete.name} (${athlete.country})`;
+                        div.onclick = () => selectGuide(athlete);
+                        guideResults.appendChild(div);
+                    });
+                }
+                guideResults.classList.remove('hidden');
+            });
+    }, 300);
+});
+
+function selectGuide(athlete) {
+    selectedGuideSdms.value = athlete.sdms;
+    guideSearch.value = '';
+    guideResults.classList.add('hidden');
+    selectedGuide.innerHTML = `Guide: <strong>${athlete.sdms}</strong> - ${athlete.name}`;
+}
+
 function selectAthlete(athlete) {
     checkAthleteCompatibility(athlete);
     selectedSdms.value = athlete.sdms;
@@ -354,6 +417,9 @@ function exportStartList() {
 document.addEventListener('click', function(e) {
     if (!athleteSearch.contains(e.target) && !athleteResults.contains(e.target)) {
         athleteResults.classList.add('hidden');
+    }
+    if (!guideSearch.contains(e.target) && !guideResults.contains(e.target)) {
+        guideResults.classList.add('hidden');
     }
 });
 </script>

--- a/templates/admin/results/manage.html
+++ b/templates/admin/results/manage.html
@@ -318,9 +318,11 @@
                         <div id="athleteResults" class="absolute z-10 w-full bg-white border rounded-lg shadow-lg mt-1 hidden max-h-60 overflow-y-auto"></div>
                     </div>
                     <input type="hidden" name="athlete_sdms" id="selectedSdms" required>
+                    <input type="hidden" name="guide_sdms" id="selectedGuideSdms">
                     <div id="selectedAthlete" class="mt-2 text-sm text-gray-600"
                          data-game-classes="{{ game.classes }}"
                          data-game-gender="{{ game.gender }}"></div>
+                    <div id="selectedGuide" class="text-xs text-gray-500"></div>
                 </div>
 
                 <!-- Performance Value (Track Events Only) -->
@@ -439,10 +441,13 @@
         <div class="grid grid-cols-2 md:grid-cols-4 gap-2">
             {% for entry in startlist %}
             <div class="border rounded p-2 text-sm cursor-pointer hover:bg-gray-50 transition-colors"
-                 onclick="selectFromStartList('{{ entry.athlete_sdms }}', '{{ entry.firstname|e }} {{ entry.lastname|e }}', '{{ entry.gender }}', '{{ entry.class }}')">
+                 onclick="selectFromStartList('{{ entry.athlete_sdms }}', '{{ entry.firstname|e }} {{ entry.lastname|e }}', '{{ entry.gender }}', '{{ entry.class }}', '{{ entry.guide_sdms or '' }}')">
                 <span class="font-semibold">{{ entry.athlete_sdms }}</span> -
                 {{ entry.firstname }} {{ entry.lastname }} ({{ entry.country }})
                 <span class="text-xs bg-blue-100 text-blue-800 px-1 rounded">{{ entry.class }}</span>
+                {% if entry.guide_sdms %}
+                    <div class="text-xs text-gray-500">Guide: {{ entry.guide_sdms }}</div>
+                {% endif %}
                 {% if entry.gender != game.gender %}
                     <div class="text-xs text-yellow-700 mt-1">
                         <i class="fas fa-exclamation-triangle"></i> Gender mismatch


### PR DESCRIPTION
## Summary
- allow specifying guide classes via config
- include `is_guide` flag in `athletes` table
- store `guide_sdms` in start lists and results
- update forms, routes and models for guide details
- enhance start list and results UIs to pick and display guides
- extend manage_results.js for guide handling